### PR TITLE
Prohibit debug rays rendering on the server

### DIFF
--- a/src/main/java/com/hbm_m/util/explosions/nuclear/CraterGenerator.java
+++ b/src/main/java/com/hbm_m/util/explosions/nuclear/CraterGenerator.java
@@ -25,6 +25,8 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
 /**
@@ -228,6 +230,9 @@ public class CraterGenerator {
     }
 
     private static boolean isDebugScreenEnabled() {
+	if (FMLEnvironment.dist != Dist.CLIENT) {
+	    return false;
+	}
         try {
             Minecraft mc = Minecraft.getInstance();
             return mc != null && mc.options.renderDebug;


### PR DESCRIPTION
Отрисовка дебаг-лучей на сервере невозможна, так как `net/minecraft/client/Minecraft` недоступен нигде кроме клиента

Попытка активации всяких различных ржомб приводит к подвисанию сервака (почему не краш? маенкравд ватафа пепе фа?) и спамом ошибок:

```
[Server thread/ERROR] [net.minecraftforge.fml.loading.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/Minecraft for invalid dist DEDICATED_SERVER
```

Лог сервака (немного отредаченный приложено):

[2026-04-27-1.log](https://github.com/user-attachments/files/27140805/2026-04-27-1.log)
