### PR TITLE
Fix OBJ model transforms on Fabric to match Forge's exact pipeline

### DIFF
--- a/src/main/java/com/hbm_m/client/model/loading/ForgeCompositeUnbakedModel.java
+++ b/src/main/java/com/hbm_m/client/model/loading/ForgeCompositeUnbakedModel.java
@@ -109,18 +109,48 @@ public final class ForgeCompositeUnbakedModel implements ForgeLikeUnbakedModel {
         TextureAtlasSprite particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, textures.getOrDefault("particle", MissingTextureAtlasSprite.getLocation())));
         if (particle == null) particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, MissingTextureAtlasSprite.getLocation()));
 
-        com.mojang.math.Transformation pivotedRot = ModelStateTransforms.resolveAndPivot(modelState);
-        Matrix4f combinedM = new Matrix4f(pivotedRot.getMatrix());
-        if (transform != null) {
-            combinedM.mul(new Matrix4f(transform));
+        // Forge CompositeModel: composeRootTransformIntoModelState(modelState, rootTransform)
+        // which does: rootTransform = rootTransform.applyOrigin(-0.5, -0.5, -0.5)
+        //             newModelState.rotation = modelState.getRotation().compose(rootTransform)
+        // The children then get baked with this combined modelState, which will in turn
+        // call blockCenterToCorner() inside their own makeQuad/bakeQuads.
+        //
+        // Since our children (OBJ models) call composeForObjBaking() which already does
+        // blockCenterToCorner(), we need to pass a modelState that has the combined rotation
+        // WITHOUT the blockCenterToCorner applied yet.
+        //
+        // Forge's composeRootTransformIntoModelState:
+        //   rootTransform' = rootTransform.applyOrigin(new Vector3f(-0.5, -0.5, -0.5))
+        //   newRot = modelState.getRotation().compose(rootTransform')
+        com.mojang.math.Transformation modelRot = ModelStateTransforms.getModelStateRotation(modelState);
+        com.mojang.math.Transformation compositeRootTransform = transform != null
+                ? new com.mojang.math.Transformation(transform)
+                : com.mojang.math.Transformation.identity();
+
+        com.mojang.math.Transformation combinedRot;
+        if (ModelStateTransforms.isIdentity(compositeRootTransform)) {
+            combinedRot = modelRot;
+        } else {
+            // Forge: rootTransform.applyOrigin(-0.5, -0.5, -0.5)
+            com.mojang.math.Transformation adjustedRoot = ModelStateTransforms.applyOrigin(
+                    compositeRootTransform, new org.joml.Vector3f(-0.5f, -0.5f, -0.5f));
+            if (ModelStateTransforms.isIdentity(modelRot)) {
+                combinedRot = adjustedRoot;
+            } else {
+                // modelState.getRotation().compose(adjustedRoot)
+                Matrix4f m = new Matrix4f(modelRot.getMatrix());
+                m.mul(adjustedRoot.getMatrix());
+                combinedRot = new com.mojang.math.Transformation(m);
+            }
         }
 
-        ModelState childState = new ModelStateTransforms.PivotedModelState(new com.mojang.math.Transformation(combinedM), modelState.isUvLocked());
+        ModelState childState = new ModelStateTransforms.PivotedModelState(combinedRot,
+                modelState != null && modelState.isUvLocked());
 
         List<BakedModel> bakedKids = new ArrayList<>();
         for (var e : children.entrySet()) {
             String name = e.getKey();
-            if (visibility.containsKey(name) && Boolean.FALSE.equals(visibility.get(name))) continue;
+            if (Boolean.FALSE.equals(visibility.get(name))) continue;
             BakedModel kid = e.getValue().bake(baker, spriteGetter, childState, modelLocation);
             if (kid != null) bakedKids.add(kid);
         }

--- a/src/main/java/com/hbm_m/client/model/loading/ForgeObjUnbakedModel.java
+++ b/src/main/java/com/hbm_m/client/model/loading/ForgeObjUnbakedModel.java
@@ -85,12 +85,11 @@ public final class ForgeObjUnbakedModel implements ForgeLikeUnbakedModel {
         for (Direction d : Direction.values()) out.put(d, new ArrayList<>());
         out.put(null, new ArrayList<>());
 
-        Transformation pivotedRot = ModelStateTransforms.resolveAndPivot(modelState);
-        org.joml.Matrix4f combinedM = new org.joml.Matrix4f(pivotedRot.getMatrix());
-        if (rootTransform != null && !rootTransform.equals(Transformation.identity())) {
-            combinedM.mul(new org.joml.Matrix4f(rootTransform.getMatrix()));
-        }
-        Transformation combined = new Transformation(combinedM);
+        // Forge pipeline:
+        //   transform = rootTransform.isIdentity() ? modelState.getRotation() : modelState.getRotation().compose(rootTransform)
+        //   transformation = transform.blockCenterToCorner()
+        // Final matrix applied to verts: T(0.5) * modelState * rootTransform * T(-0.5)
+        Transformation combined = ModelStateTransforms.composeForObjBaking(modelState, rootTransform);
 
         Set<String> hidden = new HashSet<>();
         for (var e : visibility.entrySet()) if (Boolean.FALSE.equals(e.getValue())) hidden.add(e.getKey());

--- a/src/main/java/com/hbm_m/client/model/loading/HbmLoaderAdapters.java
+++ b/src/main/java/com/hbm_m/client/model/loading/HbmLoaderAdapters.java
@@ -127,8 +127,12 @@ final class HbmLoaderAdapters {
             HashMap<String, BakedModel> bakedParts = new HashMap<>();
             TextureAtlasSprite particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, textures.getOrDefault("particle", MissingTextureAtlasSprite.getLocation())));
 
-            // HBM custom loaders: use the same pipeline as ForgeObjUnbakedModel
-            com.mojang.math.Transformation combined = ModelStateTransforms.composeForObjBaking(modelState, rootTransform);
+            // On Forge, AbstractObjPartModelLoader bakes parts with IDENTITY modelState
+            // (the BakedModel handles facing rotation at runtime via transformQuadsByFacing).
+            // We only apply rootTransform here, with blockCenterToCorner for proper centering.
+            com.mojang.math.Transformation combined = ModelStateTransforms.isIdentity(rootTransform)
+                    ? com.mojang.math.Transformation.identity()
+                    : ModelStateTransforms.blockCenterToCorner(rootTransform);
 
             ObjQuadBaker.ObjQuadBakerState.MODEL = data;
             try {
@@ -193,8 +197,11 @@ final class HbmLoaderAdapters {
             HashMap<String, BakedModel> bakedParts = new HashMap<>();
             TextureAtlasSprite particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, textures.getOrDefault("particle", MissingTextureAtlasSprite.getLocation())));
 
-            // HBM custom loaders: use the same pipeline as ForgeObjUnbakedModel
-            com.mojang.math.Transformation combined = ModelStateTransforms.composeForObjBaking(modelState, rootTransform);
+            // On Forge, AbstractObjPartModelLoader bakes parts with IDENTITY modelState.
+            // Only rootTransform is applied (with blockCenterToCorner for centering).
+            com.mojang.math.Transformation combined = ModelStateTransforms.isIdentity(rootTransform)
+                    ? com.mojang.math.Transformation.identity()
+                    : ModelStateTransforms.blockCenterToCorner(rootTransform);
 
             for (var e : partToObj.entrySet()) {
                 ObjModelData data = ObjModelData.load(rm, e.getValue());

--- a/src/main/java/com/hbm_m/client/model/loading/HbmLoaderAdapters.java
+++ b/src/main/java/com/hbm_m/client/model/loading/HbmLoaderAdapters.java
@@ -127,12 +127,8 @@ final class HbmLoaderAdapters {
             HashMap<String, BakedModel> bakedParts = new HashMap<>();
             TextureAtlasSprite particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, textures.getOrDefault("particle", MissingTextureAtlasSprite.getLocation())));
 
-            com.mojang.math.Transformation pivotedRot = ModelStateTransforms.resolveAndPivot(modelState);
-            org.joml.Matrix4f combinedM = new org.joml.Matrix4f(pivotedRot.getMatrix());
-            if (rootTransform != null && !rootTransform.equals(com.mojang.math.Transformation.identity())) {
-                combinedM.mul(new org.joml.Matrix4f(rootTransform.getMatrix()));
-            }
-            com.mojang.math.Transformation combined = new com.mojang.math.Transformation(combinedM);
+            // HBM custom loaders: use the same pipeline as ForgeObjUnbakedModel
+            com.mojang.math.Transformation combined = ModelStateTransforms.composeForObjBaking(modelState, rootTransform);
 
             ObjQuadBaker.ObjQuadBakerState.MODEL = data;
             try {
@@ -197,12 +193,8 @@ final class HbmLoaderAdapters {
             HashMap<String, BakedModel> bakedParts = new HashMap<>();
             TextureAtlasSprite particle = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, textures.getOrDefault("particle", MissingTextureAtlasSprite.getLocation())));
 
-            com.mojang.math.Transformation pivotedRot = ModelStateTransforms.resolveAndPivot(modelState);
-            org.joml.Matrix4f combinedM = new org.joml.Matrix4f(pivotedRot.getMatrix());
-            if (rootTransform != null && !rootTransform.equals(com.mojang.math.Transformation.identity())) {
-                combinedM.mul(new org.joml.Matrix4f(rootTransform.getMatrix()));
-            }
-            com.mojang.math.Transformation combined = new com.mojang.math.Transformation(combinedM);
+            // HBM custom loaders: use the same pipeline as ForgeObjUnbakedModel
+            com.mojang.math.Transformation combined = ModelStateTransforms.composeForObjBaking(modelState, rootTransform);
 
             for (var e : partToObj.entrySet()) {
                 ObjModelData data = ObjModelData.load(rm, e.getValue());

--- a/src/main/java/com/hbm_m/client/model/loading/ModelStateTransforms.java
+++ b/src/main/java/com/hbm_m/client/model/loading/ModelStateTransforms.java
@@ -2,6 +2,7 @@
 package com.hbm_m.client.model.loading;
 
 import org.joml.Matrix4f;
+import org.joml.Vector3f;
 
 import com.mojang.math.Transformation;
 
@@ -15,29 +16,92 @@ public final class ModelStateTransforms {
     private ModelStateTransforms() {}
 
     /**
-     * Applies the Vanilla block center pivot (0.5, 0.5, 0.5) ONLY to the BlockState rotation.
-     * Extracts it safely so it doesn't double-pivot if already processed.
+     * Returns the raw modelState rotation. Does NOT add an extra pivot layer,
+     * because BlockModelRotation.getRotation() already contains the pivot internally.
+     *
+     * Forge equivalent: just uses modelTransform.getRotation() directly.
      */
-    public static Transformation resolveAndPivot(ModelState state) {
+    public static Transformation getModelStateRotation(ModelState state) {
         if (state == null) return Transformation.identity();
-
-        // If it's already processed by a parent composite model, use it directly
-        if (state instanceof PivotedModelState) {
-            return state.getRotation();
-        }
-
         Transformation rot = state.getRotation();
-        if (rot == null || rot.equals(Transformation.identity())) {
-            return Transformation.identity();
+        if (rot == null || isIdentity(rot)) return Transformation.identity();
+        return rot;
+    }
+
+    /**
+     * Composes modelState rotation and rootTransform following Forge's exact pipeline:
+     * <pre>
+     *   combined = modelState.compose(rootTransform)
+     *   final = combined.blockCenterToCorner()
+     *         = T(0.5) * combined * T(-0.5)
+     *         = T(0.5) * modelState * rootTransform * T(-0.5)
+     * </pre>
+     *
+     * This is the matrix actually applied to OBJ vertex positions.
+     */
+    public static Transformation composeForObjBaking(ModelState state, Transformation rootTransform) {
+        Transformation modelRot = getModelStateRotation(state);
+
+        Transformation combined;
+        if (isIdentity(rootTransform)) {
+            combined = modelRot;
+        } else if (isIdentity(modelRot)) {
+            combined = rootTransform;
+        } else {
+            // Forge: modelTransform.getRotation().compose(rootTransform)
+            // compose = this.matrix * other.matrix
+            Matrix4f m = new Matrix4f(modelRot.getMatrix());
+            m.mul(rootTransform.getMatrix());
+            combined = new Transformation(m);
         }
 
-        Matrix4f m = new Matrix4f(rot.getMatrix());
-        Matrix4f pivoted = new Matrix4f()
-                .translation(0.5f, 0.5f, 0.5f)
-                .mul(m)
-                .translate(-0.5f, -0.5f, -0.5f);
+        if (isIdentity(combined)) return Transformation.identity();
 
-        return new Transformation(pivoted);
+        // Forge: transform.blockCenterToCorner() = applyOrigin(0.5, 0.5, 0.5)
+        return blockCenterToCorner(combined);
+    }
+
+    /**
+     * Replicates Forge's Transformation.blockCenterToCorner():
+     * <pre>
+     *   result = T(origin) * transform * T(-origin)
+     * </pre>
+     * where origin = (0.5, 0.5, 0.5).
+     *
+     * This converts from a "center of block" reference to a "corner of block" reference.
+     */
+    public static Transformation blockCenterToCorner(Transformation transform) {
+        if (isIdentity(transform)) return Transformation.identity();
+        return applyOrigin(transform, new Vector3f(0.5f, 0.5f, 0.5f));
+    }
+
+    /**
+     * Replicates Forge's IForgeTransformation.applyOrigin():
+     * <pre>
+     *   Matrix4f ret = transform.getMatrix();
+     *   Matrix4f tmp = new Matrix4f().translation(origin);
+     *   tmp.mul(ret, ret);       // ret = T(origin) * transform
+     *   tmp.translation(-origin);
+     *   ret.mul(tmp);            // ret = T(origin) * transform * T(-origin)
+     * </pre>
+     */
+    public static Transformation applyOrigin(Transformation transform, Vector3f origin) {
+        if (isIdentity(transform)) return Transformation.identity();
+
+        Matrix4f ret = new Matrix4f(transform.getMatrix());
+        Matrix4f tmp = new Matrix4f().translation(origin.x(), origin.y(), origin.z());
+        tmp.mul(ret, ret);  // ret = tmp * ret = T(origin) * transform
+        tmp.translation(-origin.x(), -origin.y(), -origin.z());
+        ret.mul(tmp);       // ret = ret * T(-origin) = T(origin) * transform * T(-origin)
+        return new Transformation(ret);
+    }
+
+    public static boolean isIdentity(Transformation t) {
+        if (t == null) return true;
+        if (t.equals(Transformation.identity())) return true;
+        Matrix4f m = new Matrix4f(t.getMatrix());
+        Matrix4f identity = new Matrix4f().identity();
+        return m.equals(identity, 1e-5f);
     }
 
     public static class PivotedModelState implements ModelState {

--- a/src/main/java/com/hbm_m/client/model/loading/ObjQuadBaker.java
+++ b/src/main/java/com/hbm_m/client/model/loading/ObjQuadBaker.java
@@ -55,7 +55,6 @@ final class ObjQuadBaker {
                                       boolean shade) {
         boolean hasTransform = transform != null && !transform.equals(Transformation.identity());
 
-        // NO MORE PIVOT HACKS HERE! We apply strictly the finalized absolute Matrix4f.
         Matrix4f m = hasTransform ? new Matrix4f(transform.getMatrix()) : new Matrix4f().identity();
         Matrix3f normalM = hasTransform ? new Matrix3f(m).invert().transpose() : null;
 
@@ -91,6 +90,8 @@ final class ObjQuadBaker {
             norm[i] = n0;
         }
 
+        // Forge uses the first vertex normal for direction determination in makeQuad.
+        // This matches: quadBaker.setDirection(Direction.getNearest(normal.x(), normal.y(), normal.z())) at i==0
         Direction dir = Direction.getNearest(norm[0].x(), norm[0].y(), norm[0].z());
 
         int packed = packNormal(norm[0].x(), norm[0].y(), norm[0].z());
@@ -103,36 +104,59 @@ final class ObjQuadBaker {
         return new BakedQuad(data, -1, dir, sprite, shade);
     }
 
+    /**
+     * Forge's automatic culling logic from ObjModel.makeQuad():
+     * Checks that ALL 4 vertices lie on the face of the unit cube corresponding to the direction,
+     * AND that the normal points outward in that direction.
+     *
+     * Forge uses Mth.equal(a, b) which checks |a - b| < 1e-5f.
+     */
     static void addQuadWithCulling(BakedQuad q, Map<Direction, List<BakedQuad>> out, boolean automaticCulling) {
-        Direction d = q.getDirection();
-        if (!automaticCulling || d == null) {
+        if (!automaticCulling) {
             out.get(null).add(q);
             return;
         }
 
-        boolean onBorder = true;
-        float eps = 1e-4f;
         int[] v = q.getVertices();
+        float[] px = new float[4], py = new float[4], pz = new float[4];
         for (int i = 0; i < 4; i++) {
-            float x = Float.intBitsToFloat(v[i * 8]);
-            float y = Float.intBitsToFloat(v[i * 8 + 1]);
-            float z = Float.intBitsToFloat(v[i * 8 + 2]);
-            switch (d) {
-                case DOWN -> { if (y > eps) onBorder = false; }
-                case UP -> { if (y < 1.0f - eps) onBorder = false; }
-                case WEST -> { if (x > eps) onBorder = false; }
-                case EAST -> { if (x < 1.0f - eps) onBorder = false; }
-                case NORTH -> { if (z > eps) onBorder = false; }
-                case SOUTH -> { if (z < 1.0f - eps) onBorder = false; }
-            }
-            if (!onBorder) break;
+            px[i] = Float.intBitsToFloat(v[i * 8]);
+            py[i] = Float.intBitsToFloat(v[i * 8 + 1]);
+            pz[i] = Float.intBitsToFloat(v[i * 8 + 2]);
         }
 
-        if (onBorder) {
-            out.get(d).add(q);
+        // Extract first vertex normal for direction check (matches Forge using norm[0])
+        int packedN = v[7]; // first vertex, offset 7 = normal
+        float nx = ((byte)(packedN & 0xFF)) / 127.0f;
+        float ny = ((byte)((packedN >> 8) & 0xFF)) / 127.0f;
+        float nz = ((byte)((packedN >> 16) & 0xFF)) / 127.0f;
+
+        Direction cull = null;
+
+        // Forge checks: all 4 positions equal to border value AND normal points outward
+        if (mthEqual(px[0], 0) && mthEqual(px[1], 0) && mthEqual(px[2], 0) && mthEqual(px[3], 0) && nx < 0) {
+            cull = Direction.WEST;
+        } else if (mthEqual(px[0], 1) && mthEqual(px[1], 1) && mthEqual(px[2], 1) && mthEqual(px[3], 1) && nx > 0) {
+            cull = Direction.EAST;
+        } else if (mthEqual(pz[0], 0) && mthEqual(pz[1], 0) && mthEqual(pz[2], 0) && mthEqual(pz[3], 0) && nz < 0) {
+            cull = Direction.NORTH;
+        } else if (mthEqual(pz[0], 1) && mthEqual(pz[1], 1) && mthEqual(pz[2], 1) && mthEqual(pz[3], 1) && nz > 0) {
+            cull = Direction.SOUTH;
+        } else if (mthEqual(py[0], 0) && mthEqual(py[1], 0) && mthEqual(py[2], 0) && mthEqual(py[3], 0) && ny < 0) {
+            cull = Direction.DOWN;
+        } else if (mthEqual(py[0], 1) && mthEqual(py[1], 1) && mthEqual(py[2], 1) && mthEqual(py[3], 1) && ny > 0) {
+            cull = Direction.UP;
+        }
+
+        if (cull != null) {
+            out.get(cull).add(q);
         } else {
             out.get(null).add(q);
         }
+    }
+
+    private static boolean mthEqual(float a, float b) {
+        return Math.abs(a - b) < 1e-5f;
     }
 
     private static void putVertex(int[] data, int v, Vector4f pos, float[] uv, int packedNormal) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Fabric OBJ model loader (`com/hbm_m/client/model/loading`) was producing incorrect transforms and rotations compared to Forge. Three types of behavior were observed:

- **Type 1** (correct): Blocks with symmetric rootTransform (barrel) or no facing (geiger_counter)
- **Type 2** (consistent offset): `forge:composite` models with asymmetric rootTransform (anvil, airbomb, wood_burner)
- **Type 3** (variable offset per facing): HBM custom loader models (battery_socket, fluid_tank)

## Root Cause Analysis

After cloning Forge 1.20.x and analyzing the complete pipeline, two separate issues were found:

### Issue 1: Core transform pipeline mismatch

The general `blockCenterToCorner()` logic was incorrectly implemented:
- **Old code**: Manually applied pivot `T(0.5)*R*T(-0.5)` in `resolveAndPivot()` even though `BlockModelRotation.getRotation()` already contains the pivot internally (double-pivot).
- **Forge behavior**: `T(0.5) * modelState * rootTransform * T(-0.5)` applied via `compose() + blockCenterToCorner()`

### Issue 2: HBM custom loaders applied blockState rotation during baking

On Forge, `AbstractObjPartModelLoader` bakes parts with **identity ModelState** — the BakedModel handles facing at RUNTIME via `ModelHelper.transformQuadsByFacing()`. The Fabric implementation was applying blockState rotation during baking, causing **double rotation**.

## Fixes

| Commit | Changes |
|--------|---------|
| 1st | Complete rewrite of `ModelStateTransforms` to replicate Forge's exact `blockCenterToCorner()`/`applyOrigin()`. Fix `ForgeObjUnbakedModel` and `ForgeCompositeUnbakedModel` transform composition. Rewrite `ObjQuadBaker` culling to match Forge. |
| 2nd | HBM custom loaders (`ObjPartsUnbakedModel`, `MultiObjUnbakedModel`) now only apply `rootTransform` with `blockCenterToCorner()`, matching Forge's identity-modelState baking. |

## Verification

- ✅ `./gradlew :1.20.1-fabric:compileJava --rerun-tasks` — BUILD SUCCESSFUL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87eeffde-b28c-46d1-b3ee-3ca36ed15b50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87eeffde-b28c-46d1-b3ee-3ca36ed15b50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

