### PR TITLE
Port hardware instancing renderer to Fabric + fix Cloth Config crash

### DIFF
--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -77,6 +77,9 @@ repositories {
 
 	// Compile-only Forge API to keep shared sources compiling on Fabric.
 	maven("https://maven.minecraftforge.net") { name = "Forge Maven" }
+
+	// Cloth Config (Shedaniel Maven) — resolves basic-math transitive correctly
+	maven("https://maven.shedaniel.me/") { name = "Shedaniel" }
 }
 
 dependencies {
@@ -107,8 +110,8 @@ dependencies {
 	// Fabric compat: external energy via TeamReborn Energy API (bundled)
 	modApi("teamreborn:energy:3.0.0")
 	include("teamreborn:energy:3.0.0")
-	include("curse.maven:cloth-config-348521:5729104")
-	modApi("curse.maven:cloth-config-348521:5729104")
+	include("me.shedaniel.cloth:cloth-config-fabric:${prop("deps.cloth-config")}")
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${prop("deps.cloth-config")}")
 	// ---- Compile-only shims for shared (Forge-origin) sources ----
 	// These MUST NOT end up in the Fabric runtime jar.
 	// compileOnly("net.minecraftforge:forge:1.20.1-47.4.20:universal")

--- a/src/main/java/com/hbm_m/client/ClientSetup.java
+++ b/src/main/java/com/hbm_m/client/ClientSetup.java
@@ -86,6 +86,7 @@ import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.client.Minecraft;
@@ -129,6 +130,7 @@ public class ClientSetup {
 
         //? if fabric {
         com.hbm_m.client.model.loading.ForgeLikeModelLoadingFabric.init();
+        registerFabricShaders();
         //?}
 
         // Экраны меню - vanilla API, одинаково работает на обоих лоадерах.
@@ -158,6 +160,102 @@ public class ClientSetup {
         // Клиентские тэги/настройки рендера, общие для обоих.
         OcclusionCullingHelper.setTransparentBlocksTag(ModTags.Blocks.NON_OCCLUDING);
     }
+
+    //? if fabric {
+    private static void registerFabricShaders() {
+        CoreShaderRegistrationCallback.EVENT.register(context -> {
+            MainRegistry.LOGGER.info("Registering optimized shaders (Fabric)...");
+
+            VertexFormat blockLitSimpleFormat = new VertexFormat(
+                ImmutableMap.<String, VertexFormatElement>builder()
+                    .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
+                    .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
+                    .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
+                    .build()
+            );
+
+            VertexFormat blockLitInstancedFormat = new VertexFormat(
+                ImmutableMap.<String, VertexFormatElement>builder()
+                    .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
+                    .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
+                    .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
+                    .put("InstPos", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 3))
+                    .put("InstRot", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 4))
+                    .put("InstBrightness", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 1))
+                    .build()
+            );
+
+            ResourceLocation realVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit.vsh");
+            ResourceLocation virtualInstancedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced.vsh");
+            ResourceLocation virtualSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_sliced.vsh");
+            ResourceLocation virtualInstancedSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced_sliced.vsh");
+
+            com.hbm_m.client.render.shader.modification.ShaderModification instancingDefine =
+                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                    .define("USE_INSTANCING");
+
+            com.hbm_m.client.render.shader.modification.ShaderModification slicedDefine =
+                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                    .define("USE_SLICED_LIGHT");
+
+            com.hbm_m.client.render.shader.modification.ShaderModification instancedSlicedDefine =
+                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                    .define("USE_INSTANCING")
+                    .define("USE_SLICED_LIGHT");
+
+            net.minecraft.server.packs.resources.ResourceProvider vanillaProvider =
+                Minecraft.getInstance().getResourceManager();
+
+            net.minecraft.server.packs.resources.ResourceProvider instancedProvider =
+                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                    vanillaProvider, virtualInstancedVsh, realVsh, instancingDefine);
+
+            net.minecraft.server.packs.resources.ResourceProvider slicedProvider =
+                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                    vanillaProvider, virtualSlicedVsh, realVsh, slicedDefine);
+
+            net.minecraft.server.packs.resources.ResourceProvider instancedSlicedProvider =
+                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                    vanillaProvider, virtualInstancedSlicedVsh, realVsh, instancedSlicedDefine);
+
+            try {
+                ShaderInstance simpleShader = new ShaderInstance(
+                    vanillaProvider,
+                    MainRegistry.MOD_ID + ":block_lit_simple",
+                    blockLitSimpleFormat
+                );
+                ModShaders.setBlockLitSimpleShader(simpleShader);
+                MainRegistry.LOGGER.info("Successfully registered block_lit_simple shader (Fabric)");
+
+                ShaderInstance instancedShader = new ShaderInstance(
+                    instancedProvider,
+                    MainRegistry.MOD_ID + ":block_lit_instanced",
+                    blockLitInstancedFormat
+                );
+                ModShaders.setBlockLitInstancedShader(instancedShader);
+                MainRegistry.LOGGER.info("Successfully registered block_lit_instanced shader (Fabric)");
+
+                ShaderInstance slicedShader = new ShaderInstance(
+                    slicedProvider,
+                    MainRegistry.MOD_ID + ":block_lit_simple_sliced",
+                    blockLitSimpleFormat
+                );
+                ModShaders.setBlockLitSimpleSlicedShader(slicedShader);
+                MainRegistry.LOGGER.info("Successfully registered block_lit_simple_sliced shader (Fabric)");
+
+                ShaderInstance instancedSlicedShader = new ShaderInstance(
+                    instancedSlicedProvider,
+                    MainRegistry.MOD_ID + ":block_lit_instanced_sliced",
+                    blockLitInstancedFormat
+                );
+                ModShaders.setBlockLitInstancedSlicedShader(instancedSlicedShader);
+                MainRegistry.LOGGER.info("Successfully registered block_lit_instanced_sliced shader (Fabric)");
+            } catch (IOException e) {
+                MainRegistry.LOGGER.error("Failed to register shaders on Fabric", e);
+            }
+        });
+    }
+    //?}
 
     //? if forge {
     /*@SubscribeEvent

--- a/src/main/java/com/hbm_m/client/ClientSetup.java
+++ b/src/main/java/com/hbm_m/client/ClientSetup.java
@@ -86,7 +86,6 @@ import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.client.Minecraft;
@@ -162,98 +161,113 @@ public class ClientSetup {
     }
 
     //? if fabric {
+    private static volatile boolean fabricShadersLoaded = false;
+
     private static void registerFabricShaders() {
-        CoreShaderRegistrationCallback.EVENT.register(context -> {
-            MainRegistry.LOGGER.info("Registering optimized shaders (Fabric)...");
+        ResourceManagerHelper.get(PackType.CLIENT_RESOURCES).registerReloadListener(
+            new net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener() {
+                @Override
+                public net.minecraft.resources.ResourceLocation getFabricId() {
+                    return new ResourceLocation(MainRegistry.MOD_ID, "shader_loader");
+                }
 
-            VertexFormat blockLitSimpleFormat = new VertexFormat(
-                ImmutableMap.<String, VertexFormatElement>builder()
-                    .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
-                    .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
-                    .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
-                    .build()
-            );
-
-            VertexFormat blockLitInstancedFormat = new VertexFormat(
-                ImmutableMap.<String, VertexFormatElement>builder()
-                    .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
-                    .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
-                    .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
-                    .put("InstPos", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 3))
-                    .put("InstRot", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 4))
-                    .put("InstBrightness", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 1))
-                    .build()
-            );
-
-            ResourceLocation realVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit.vsh");
-            ResourceLocation virtualInstancedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced.vsh");
-            ResourceLocation virtualSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_sliced.vsh");
-            ResourceLocation virtualInstancedSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced_sliced.vsh");
-
-            com.hbm_m.client.render.shader.modification.ShaderModification instancingDefine =
-                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
-                    .define("USE_INSTANCING");
-
-            com.hbm_m.client.render.shader.modification.ShaderModification slicedDefine =
-                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
-                    .define("USE_SLICED_LIGHT");
-
-            com.hbm_m.client.render.shader.modification.ShaderModification instancedSlicedDefine =
-                com.hbm_m.client.render.shader.modification.ShaderModification.builder()
-                    .define("USE_INSTANCING")
-                    .define("USE_SLICED_LIGHT");
-
-            net.minecraft.server.packs.resources.ResourceProvider vanillaProvider =
-                Minecraft.getInstance().getResourceManager();
-
-            net.minecraft.server.packs.resources.ResourceProvider instancedProvider =
-                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
-                    vanillaProvider, virtualInstancedVsh, realVsh, instancingDefine);
-
-            net.minecraft.server.packs.resources.ResourceProvider slicedProvider =
-                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
-                    vanillaProvider, virtualSlicedVsh, realVsh, slicedDefine);
-
-            net.minecraft.server.packs.resources.ResourceProvider instancedSlicedProvider =
-                com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
-                    vanillaProvider, virtualInstancedSlicedVsh, realVsh, instancedSlicedDefine);
-
-            try {
-                ShaderInstance simpleShader = new ShaderInstance(
-                    vanillaProvider,
-                    MainRegistry.MOD_ID + ":block_lit_simple",
-                    blockLitSimpleFormat
-                );
-                ModShaders.setBlockLitSimpleShader(simpleShader);
-                MainRegistry.LOGGER.info("Successfully registered block_lit_simple shader (Fabric)");
-
-                ShaderInstance instancedShader = new ShaderInstance(
-                    instancedProvider,
-                    MainRegistry.MOD_ID + ":block_lit_instanced",
-                    blockLitInstancedFormat
-                );
-                ModShaders.setBlockLitInstancedShader(instancedShader);
-                MainRegistry.LOGGER.info("Successfully registered block_lit_instanced shader (Fabric)");
-
-                ShaderInstance slicedShader = new ShaderInstance(
-                    slicedProvider,
-                    MainRegistry.MOD_ID + ":block_lit_simple_sliced",
-                    blockLitSimpleFormat
-                );
-                ModShaders.setBlockLitSimpleSlicedShader(slicedShader);
-                MainRegistry.LOGGER.info("Successfully registered block_lit_simple_sliced shader (Fabric)");
-
-                ShaderInstance instancedSlicedShader = new ShaderInstance(
-                    instancedSlicedProvider,
-                    MainRegistry.MOD_ID + ":block_lit_instanced_sliced",
-                    blockLitInstancedFormat
-                );
-                ModShaders.setBlockLitInstancedSlicedShader(instancedSlicedShader);
-                MainRegistry.LOGGER.info("Successfully registered block_lit_instanced_sliced shader (Fabric)");
-            } catch (IOException e) {
-                MainRegistry.LOGGER.error("Failed to register shaders on Fabric", e);
+                @Override
+                public void onResourceManagerReload(net.minecraft.server.packs.resources.ResourceManager manager) {
+                    loadFabricShaders(manager);
+                }
             }
-        });
+        );
+    }
+
+    private static void loadFabricShaders(net.minecraft.server.packs.resources.ResourceManager manager) {
+        MainRegistry.LOGGER.info("Registering optimized shaders (Fabric)...");
+
+        VertexFormat blockLitSimpleFormat = new VertexFormat(
+            ImmutableMap.<String, VertexFormatElement>builder()
+                .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
+                .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
+                .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
+                .build()
+        );
+
+        VertexFormat blockLitInstancedFormat = new VertexFormat(
+            ImmutableMap.<String, VertexFormatElement>builder()
+                .put("Position", DefaultVertexFormat.ELEMENT_POSITION)
+                .put("Normal",   DefaultVertexFormat.ELEMENT_NORMAL)
+                .put("UV0",      DefaultVertexFormat.ELEMENT_UV0)
+                .put("InstPos", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 3))
+                .put("InstRot", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 4))
+                .put("InstBrightness", new VertexFormatElement(0, VertexFormatElement.Type.FLOAT, VertexFormatElement.Usage.GENERIC, 1))
+                .build()
+        );
+
+        ResourceLocation realVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit.vsh");
+        ResourceLocation virtualInstancedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced.vsh");
+        ResourceLocation virtualSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_sliced.vsh");
+        ResourceLocation virtualInstancedSlicedVsh = new ResourceLocation(MainRegistry.MOD_ID, "shaders/core/block_lit_instanced_sliced.vsh");
+
+        com.hbm_m.client.render.shader.modification.ShaderModification instancingDefine =
+            com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                .define("USE_INSTANCING");
+
+        com.hbm_m.client.render.shader.modification.ShaderModification slicedDefine =
+            com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                .define("USE_SLICED_LIGHT");
+
+        com.hbm_m.client.render.shader.modification.ShaderModification instancedSlicedDefine =
+            com.hbm_m.client.render.shader.modification.ShaderModification.builder()
+                .define("USE_INSTANCING")
+                .define("USE_SLICED_LIGHT");
+
+        net.minecraft.server.packs.resources.ResourceProvider instancedProvider =
+            com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                manager, virtualInstancedVsh, realVsh, instancingDefine);
+
+        net.minecraft.server.packs.resources.ResourceProvider slicedProvider =
+            com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                manager, virtualSlicedVsh, realVsh, slicedDefine);
+
+        net.minecraft.server.packs.resources.ResourceProvider instancedSlicedProvider =
+            com.hbm_m.client.render.shader.modification.ShaderPreDefinitions.wrapRedirect(
+                manager, virtualInstancedSlicedVsh, realVsh, instancedSlicedDefine);
+
+        try {
+            ShaderInstance simpleShader = new ShaderInstance(
+                manager,
+                MainRegistry.MOD_ID + ":block_lit_simple",
+                blockLitSimpleFormat
+            );
+            ModShaders.setBlockLitSimpleShader(simpleShader);
+            MainRegistry.LOGGER.info("Successfully registered block_lit_simple shader (Fabric)");
+
+            ShaderInstance instancedShader = new ShaderInstance(
+                instancedProvider,
+                MainRegistry.MOD_ID + ":block_lit_instanced",
+                blockLitInstancedFormat
+            );
+            ModShaders.setBlockLitInstancedShader(instancedShader);
+            MainRegistry.LOGGER.info("Successfully registered block_lit_instanced shader (Fabric)");
+
+            ShaderInstance slicedShader = new ShaderInstance(
+                slicedProvider,
+                MainRegistry.MOD_ID + ":block_lit_simple_sliced",
+                blockLitSimpleFormat
+            );
+            ModShaders.setBlockLitSimpleSlicedShader(slicedShader);
+            MainRegistry.LOGGER.info("Successfully registered block_lit_simple_sliced shader (Fabric)");
+
+            ShaderInstance instancedSlicedShader = new ShaderInstance(
+                instancedSlicedProvider,
+                MainRegistry.MOD_ID + ":block_lit_instanced_sliced",
+                blockLitInstancedFormat
+            );
+            ModShaders.setBlockLitInstancedSlicedShader(instancedSlicedShader);
+            MainRegistry.LOGGER.info("Successfully registered block_lit_instanced_sliced shader (Fabric)");
+
+            fabricShadersLoaded = true;
+        } catch (IOException e) {
+            MainRegistry.LOGGER.error("Failed to register shaders on Fabric", e);
+        }
     }
     //?}
 


### PR DESCRIPTION
## Problems

### 1. Invisible models on Fabric (hardware instancing renderer)
All blocks using the hardware instancing renderer (`InstancedStaticPartRenderer`, `SingleMeshVboRenderer`) were invisible when placed.

**Root cause:** `onRegisterShaders` (lines 981-1175 of `ClientSetup.java`) was entirely inside a `//? if forge { }` Stonecutter guard. On Fabric, `ModShaders` fields stayed `null`, so the GPU renderers drew nothing.

**Fix:** Added `registerFabricShaders()` using Fabric's `SimpleSynchronousResourceReloadListener`. Creates `ShaderInstance` objects with custom `ResourceProvider`s from `ShaderPreDefinitions.wrapRedirect()` for virtual `.vsh` variants with `#define` injection.

> Note: `CoreShaderRegistrationCallback` was tried first but fires ~60 times per vanilla shader load on Fabric 1.20.1 ([fabric-api#3230](https://github.com/FabricMC/fabric-api/issues/3230)), and manual `ShaderInstance` creation inside it corrupted vanilla's shader pipeline causing `NPE in VertexBuffer._drawWithShader`. The reload listener approach fires once after all vanilla shaders are loaded.

### 2. Cloth Config crash (`NoClassDefFoundError: me/shedaniel/math/Rectangle`)
Opening the config screen (Alt+0) crashed.

**Root cause:** CurseMaven (`curse.maven:cloth-config-348521:5729104`) doesn't resolve nested JARs (`META-INF/jars/basic-math-0.6.1.jar`) at dev time.

**Fix:** Switched to Shedaniel Maven (`me.shedaniel.cloth:cloth-config-fabric:${deps.cloth-config}`), which resolves transitives correctly.

## Changes
- `build.fabric.gradle.kts`: Added Shedaniel Maven repo; switched cloth-config to Maven artifact
- `ClientSetup.java`: Added Fabric shader registration via resource reload listener
