### PR TITLE
Fix Assembly Machine dedicated server crash + Turkish/Azerbaijani locale datagen crash

### DIFF
--- a/build.forge.gradle.kts
+++ b/build.forge.gradle.kts
@@ -131,5 +131,20 @@ tasks.named("createMinecraftArtifacts") {
 	dependsOn(tasks.named("stonecutterGenerate"))
 }
 
+// Datagen output (src/generated/resources) is wired into the main sourceSet above, but it
+// deliberately is NOT hooked into `build`. Do not add processResources.dependsOn("runData"):
+// runData's runtime classpath is the main sourceSet output, so runData already depends on
+// classes -> processResources. Adding the reverse edge produces
+//   classes -> processResources -> runData -> classes
+// and Gradle fails with a circular dependency. mustRunAfter cannot help either, since the
+// required ordering is genuinely contradictory within a single task graph.
+//
+// Datagen is therefore a two-invocation workflow, run it after changing any provider:
+//   ./gradlew :<version>:runData
+//   ./gradlew :<version>:build
+// A fresh clone has no generated resources at all (.gitignore excludes blockstates/, models/
+// and data/), so runData is mandatory before the first build or most blocks ship without
+// blockstates, recipes and loot tables.
+
 stonecutter {
 }

--- a/src/main/java/com/hbm_m/block/generic/BlockAbsorber.java
+++ b/src/main/java/com/hbm_m/block/generic/BlockAbsorber.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.storage.loot.LootParams;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Поглотитель радиации с четырьмя уровнями (порт {@link com.hbm.blocks.generic.BlockAbsorber} 1.7.10).
@@ -49,7 +50,10 @@ public class BlockAbsorber extends Block {
 
         @Override
         public String getSerializedName() {
-            return name().toLowerCase();
+            // Locale.ROOT is required: this value becomes a blockstate property name, which
+            // Minecraft validates against [a-z0-9_]. Under a Turkish locale the default
+            // toLowerCase() maps PINK -> "pdotless-i-nk", failing registration of every block.
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/main/java/com/hbm_m/blockentity/machines/MachineAdvancedAssemblerBlockEntity.java
+++ b/src/main/java/com/hbm_m/blockentity/machines/MachineAdvancedAssemblerBlockEntity.java
@@ -815,14 +815,14 @@ public class MachineAdvancedAssemblerBlockEntity extends BaseMachineBlockEntity 
         return clientTicker != null ? clientTicker.getArms() : new AdvancedAssemblerClientTicker.AssemblerArm[0];
     }
 
-    @Environment(EnvType.CLIENT)
+    // NOTE: no @Environment(EnvType.CLIENT) on these fields -- see the Forge branch below;
+    // an annotated field is stripped on a dedicated server while the constructor's PUTFIELD
+    // survives, producing NoSuchFieldError on block entity creation.
     @Nullable
     private ResourceLocation clientRecipeIconCacheId;
 
-    @Environment(EnvType.CLIENT)
     private ItemStack clientRecipeIconCache = ItemStack.EMPTY;
 
-    @Environment(EnvType.CLIENT)
     public ItemStack getClientRecipeIcon() {
         ResourceLocation id = selectedRecipeId;
         if (id == null) {
@@ -849,15 +849,16 @@ public class MachineAdvancedAssemblerBlockEntity extends BaseMachineBlockEntity 
     *///?}
 
     //? if forge {
-    @OnlyIn(Dist.CLIENT)
+    // NOTE: no @OnlyIn(Dist.CLIENT) on these fields. Field initializers are compiled into the
+    // constructor, which is not side-stripped, so an annotated field would be removed on a
+    // dedicated server while its PUTFIELD survives -> NoSuchFieldError on block entity creation.
+    // These are only ever read from the client renderer; on a server they just stay empty.
     @Nullable
     private ResourceLocation clientRecipeIconCacheId;
 
-    @OnlyIn(Dist.CLIENT)
     private ItemStack clientRecipeIconCache = ItemStack.EMPTY;
 
     /** Cached recipe output icon for BER; refreshed when {@link #selectedRecipeId} changes. */
-    @OnlyIn(Dist.CLIENT)
     public ItemStack getClientRecipeIcon() {
         ResourceLocation id = selectedRecipeId;
         if (id == null) {

--- a/src/main/java/com/hbm_m/blockentity/machines/MachineAssemblerBlockEntity.java
+++ b/src/main/java/com/hbm_m/blockentity/machines/MachineAssemblerBlockEntity.java
@@ -771,13 +771,13 @@ public class MachineAssemblerBlockEntity extends BaseMachineBlockEntity {
     // ==================== CLIENT ====================
 
     //? if fabric {
-    /*@Environment(EnvType.CLIENT)
+    /*// NOTE: no @Environment(EnvType.CLIENT) on these fields -- see the Forge branch below;
+    // an annotated field is stripped on a dedicated server while the constructor's PUTFIELD
+    // survives, producing NoSuchFieldError on block entity creation.
     private ItemStack clientRecipeIconTemplate = ItemStack.EMPTY;
 
-    @Environment(EnvType.CLIENT)
     private ItemStack clientRecipeIconCache = ItemStack.EMPTY;
 
-    @Environment(EnvType.CLIENT)
     public ItemStack getClientRecipeIcon() {
         ItemStack template = getInventory().getStackInSlot(TEMPLATE_SLOT);
         if (ItemStack.matches(template, clientRecipeIconTemplate)) {
@@ -794,14 +794,15 @@ public class MachineAssemblerBlockEntity extends BaseMachineBlockEntity {
     *///?}
 
     //? if forge {
-    @OnlyIn(Dist.CLIENT)
+    // NOTE: no @OnlyIn(Dist.CLIENT) on these fields. Field initializers are compiled into the
+    // constructor, which is not side-stripped, so an annotated field would be removed on a
+    // dedicated server while its PUTFIELD survives -> NoSuchFieldError on block entity creation.
+    // These are only ever read from the client renderer; on a server they just stay empty.
     private ItemStack clientRecipeIconTemplate = ItemStack.EMPTY;
 
-    @OnlyIn(Dist.CLIENT)
     private ItemStack clientRecipeIconCache = ItemStack.EMPTY;
 
     /** Cached recipe output icon for BER; refreshed when assembly template slot changes. */
-    @OnlyIn(Dist.CLIENT)
     public ItemStack getClientRecipeIcon() {
         ItemStack template = getInventory().getStackInSlot(TEMPLATE_SLOT);
         if (ItemStack.matches(template, clientRecipeIconTemplate)) {

--- a/src/main/java/com/hbm_m/blockentity/machines/MachineFrackingTowerBlockEntity.java
+++ b/src/main/java/com/hbm_m/blockentity/machines/MachineFrackingTowerBlockEntity.java
@@ -3,6 +3,8 @@ package com.hbm_m.blockentity.machines;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 import com.hbm_m.block.ModBlocks;
 import com.hbm_m.blockentity.BaseMachineBlockEntity;
 import com.hbm_m.blockentity.ModBlockEntities;
@@ -435,7 +437,7 @@ public class MachineFrackingTowerBlockEntity extends BaseMachineBlockEntity {
                 for (int z = worldPosition.getZ() - range; z <= worldPosition.getZ() + range; z++) {
                     BlockPos checkPos = new BlockPos(x, y, z);
                     Block block = level.getBlockState(checkPos).getBlock();
-                    String blockName = block.getDescriptionId().toLowerCase();
+                    String blockName = block.getDescriptionId().toLowerCase(Locale.ROOT);
                     
                     if (blockName.contains("oil") && blockName.contains("ore")) {
                         return checkPos;

--- a/src/main/java/com/hbm_m/blockentity/machines/MachineRadarBlockEntity.java
+++ b/src/main/java/com/hbm_m/blockentity/machines/MachineRadarBlockEntity.java
@@ -36,6 +36,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+
+import java.util.Locale;
 //? if forge {
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 //?}
@@ -331,7 +333,7 @@ public class MachineRadarBlockEntity extends BaseMachineBlockEntity {
         if (entity instanceof IRadarDetectable detectable) {
             return detectable.getTargetType() != IRadarDetectable.RadarTargetType.PLAYER;
         }
-        String name = entity.getType().toString().toLowerCase();
+        String name = entity.getType().toString().toLowerCase(Locale.ROOT);
         return name.contains("missile")
                 || name.contains("rocket")
                 || name.contains("airstrike")
@@ -344,8 +346,8 @@ public class MachineRadarBlockEntity extends BaseMachineBlockEntity {
             return false;
         }
 
-        String typeName = living.getType().toString().toLowerCase();
-        String displayName = living.getName().getString().toLowerCase();
+        String typeName = living.getType().toString().toLowerCase(Locale.ROOT);
+        String displayName = living.getName().getString().toLowerCase(Locale.ROOT);
         return typeName.contains("digamma")
                 || typeName.contains("jam")
                 || displayName.contains("digamma")

--- a/src/main/java/com/hbm_m/item/industrial/ItemMachineUpgrade.java
+++ b/src/main/java/com/hbm_m/item/industrial/ItemMachineUpgrade.java
@@ -11,6 +11,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 
+import java.util.Locale;
+
 /**
  * Апгрейд машины — порт ItemMachineUpgrade из 1.7.10.
  *
@@ -29,7 +31,9 @@ public class ItemMachineUpgrade extends Item {
         OVERDRIVE;
 
         public String getTranslationKeySuffix() {
-            return name().toLowerCase();
+            // Locale.ROOT: OVERDRIVE would lowercase to a dotless i under a Turkish locale,
+            // producing a translation key that matches nothing in the lang files.
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/main/java/com/hbm_m/item/missile/MissileItem.java
+++ b/src/main/java/com/hbm_m/item/missile/MissileItem.java
@@ -11,6 +11,8 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 /**
  * Прототип предмета ракеты для пусковых площадок.
  *
@@ -50,7 +52,7 @@ public class MissileItem extends Item {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flag) {
         // Tier localized: missile.tier.tier0, missile.tier.tier1, ...
-        String tierKey = "item.hbm_m.missile.tier." + this.tier.name().toLowerCase();
+        String tierKey = "item.hbm_m.missile.tier." + this.tier.name().toLowerCase(Locale.ROOT);
         tooltip.add(Component.translatable(tierKey).withStyle(ChatFormatting.ITALIC));
 
         if (!this.launchable) {

--- a/src/main/java/com/hbm_m/powerarmor/overlay/HbmThermalHandler.java
+++ b/src/main/java/com/hbm_m/powerarmor/overlay/HbmThermalHandler.java
@@ -19,6 +19,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
+import java.util.Locale;
+
 /**
  * Тепловизор (FULL_SHADER): общий обработчик состояния/шейдера.
  *
@@ -231,7 +233,7 @@ public class HbmThermalHandler implements ResourceManagerReloadListener {
 
         @Override
         public com.mojang.blaze3d.vertex.VertexConsumer getBuffer(net.minecraft.client.renderer.RenderType type) {
-            String name = type.toString().toLowerCase();
+            String name = type.toString().toLowerCase(Locale.ROOT);
 
             // Тени/шлейфы/глинт и прочее лишнее нам не нужно в тепловизоре.
             // Возвращаем noOp, чтобы ItemRenderer не создавал дублирующиеся VertexMultiConsumer'ы


### PR DESCRIPTION
## Bug 1: Assembly Machine crashes dedicated server on placement

`MachineAdvancedAssemblerBlockEntity` and `MachineAssemblerBlockEntity` declare
fields like `clientRecipeIconCache` with `@OnlyIn(Dist.CLIENT)` AND a field
initializer (`= ItemStack.EMPTY`). Forge's RuntimeDistCleaner strips the
annotated field on dedicated servers, but the field initializer is compiled
into the constructor regardless — so the constructor's `putfield` targets a
field that no longer exists, throwing `NoSuchFieldError` the moment the block
entity is constructed. Since ladder-detection logic touches nearby block
entities every tick, this reliably kicks any player near the block with
"Internal server error."

Fix: removed `@OnlyIn` from these fields (Forge docs recommend against
`@OnlyIn` on mod-owned fields in general — it's meant for vanilla side
stripping). Fields now exist server-side too, harmlessly unused.

## Bug 2: Turkish/Azerbaijani locale crashes datagen entirely

Several call sites build blockstate property values and translation keys via
`name().toLowerCase()` without a Locale. Under tr-TR/az-Latn locale,
`"PINK".toLowerCase()` produces "pınk" (dotless ı), which fails Minecraft's
`[a-z0-9_]` blockstate property validation and aborts registration of that
block entirely — which cascades into `Registry Object not present` errors
for unrelated blocks and kills the whole datagen run. This only reproduces
on Turkish/Azerbaijani systems, which is likely why it went unnoticed.

Fix: switched the affected calls to `Locale.ROOT`, matching the ~25 other
call sites in the codebase that already do this correctly. Affected files:
`BlockAbsorber`, `ItemMachineUpgrade`, `MissileItem`,
`MachineRadarBlockEntity` (x3), `MachineFrackingTowerBlockEntity`,
`HbmThermalHandler`.

## Testing

- Dedicated server no longer crashes on Assembly Machine placement.
- `runData` completes cleanly (0 errors) on tr-TR locale.
- Verified generated asset counts before/after the fix:

| | Before | After |
|---|---|---|
| blockstates | 107 | 553 |
| models/block | 686 | 1276 |
| models/item | 151 | 1767 |
| recipes | 0 | 557 |
| loot_tables | 0 | 551 |

- Confirmed `rad_absorber.json` now generates `tier=pink` (lowercase, valid)
  instead of crashing with `tier=pınk`.
- Verified translations (110 languages, including tr_tr) are preserved in
  the final jar — `runData` marks non-generated language files as stale
  and removes them (`removed stale: 108`), so a `git checkout` of
  `src/generated/resources/assets/hbm_m/lang/` is required after running
  `runData` and before `build`. Left a comment in `build.forge.gradle.kts`
  explaining why `processResources` is intentionally not wired to depend
  on `runData` (it creates a circular task dependency:
  `classes → processResources → runData → classes`).

Two-step build workflow after these changes:
./gradlew :1.20.1-forge:runData
git checkout -- src/generated/resources/assets/hbm_m/lang/
./gradlew :1.20.1-forge:build